### PR TITLE
Added ability to create Misaka with custom renderer

### DIFF
--- a/flask_misaka.py
+++ b/flask_misaka.py
@@ -110,7 +110,7 @@ class Misaka(object):
             options = copy(options)
             options.update(overrides)
         
-        if not self.md: # no custom renderer, just use the normal markdown method
+        if not hasattr(self, 'md'): # no custom renderer, just use the normal markdown method
             return markdown(text, **options)
         else: # custom renderer
             return self.md.render(text)


### PR DESCRIPTION
Hello, I wanted the ability to create a custom renderer so that you could add preprocessing and postprocessing to the Markdown rendering. If you use the markdown method it should work the same, but if you use the Misaka() constructor with the optional _renderer_  parameter, then it will use Misaka's _render()_ method instead of _html()_. Not sure if you think others might find this useful!
